### PR TITLE
[TS] Accept `null` for root option

### DIFF
--- a/src/react-cool-inview.d.ts
+++ b/src/react-cool-inview.d.ts
@@ -27,7 +27,7 @@ declare module "react-cool-inview" {
   export type OnLeave<T extends HTMLElement | null = HTMLElement> = OnEnter<T>;
 
   export interface Options<T extends HTMLElement | null> {
-    root?: HTMLElement;
+    root?: HTMLElement | null;
     rootMargin?: string;
     threshold?: number | number[];
     trackVisibility?: boolean;


### PR DESCRIPTION
## What

Update TypeScript types, add `null` to `root` option.

## Why

Per [the doc](https://github.com/wellyshen/react-cool-inview#parameter), `root` can accept a `null` parameter but TS was complaining. This PR fixes that.
