### PR TITLE
Docs change: remove call to observe() in onEnter() handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,12 @@ const App = () => {
     // For better UX, we can grow the root margin so the data will be loaded earlier
     rootMargin: "50px 0px",
     // When the last item comes to the viewport
-    onEnter: ({ unobserve, observe }) => {
+    onEnter: ({ unobserve }) => {
       // Pause observe when loading data
       unobserve();
       // Load more data
       axios.get("/todos").then((res) => {
         setTodos([...todos, ...res.todos]);
-        // Resume observe after loading data
-        observe();
       });
     },
   });


### PR DESCRIPTION
The call to observe() is unnecessary, isn't it? Because doesn't it happen in the render call that gets triggered by setTodos?

If that's the case, and the call to observe() in the onEnter() handler is actually redundant, then I suspect that including it may cause people new to this library (like myself) to have a harder time understanding how it works.

In my particular case, I ended up fixing an onChange() handler that infinitely looped, like so:

```js
onChange: async ({ inView, unobserve, observe }) => {
  if (inView) {
    unobserve();
    await loadMoreResults();
    // The following call to observe sets up an infinite loop when the observed element
    // stays in view because observe() causes onChange({ inView: true }) which in turn
    // calls observe() and so on and so forth
    observe(); // BAD
  }
}
```

This was to implement infinite scroll. The reason I couldn't use onEnter was that it does not fire if the element is already in view when the page loads (for example, a really big monitor).

