### PR TITLE
fix: only setState when active/mounted

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,8 @@ const useInView = <T extends HTMLElement | null>({
       return () => null;
     }
 
+    let isActive = true;
+
     // eslint-disable-next-line compat/compat
     observerRef.current = new IntersectionObserver(
       ([entry]: IntersectionObserverEntryV2[]) => {
@@ -157,7 +159,7 @@ const useInView = <T extends HTMLElement | null>({
 
         if (onChangeRef.current) onChangeRef.current({ ...e, inView });
 
-        setState({ inView, scrollDirection, entry });
+        if (isActive) setState({ inView, scrollDirection, entry });
         prevInViewRef.current = inView;
       },
       {
@@ -171,7 +173,10 @@ const useInView = <T extends HTMLElement | null>({
 
     observe();
 
-    return () => unobserve();
+    return () => {
+      isActive = false;
+      unobserve();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     unobserveOnEnter,


### PR DESCRIPTION
<!--
  Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

  Before submitting a pull request, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

  Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

  If you're new to contributing to open source projects, you might find this free video course helpful: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github

  Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## What

Make sure to only call `setState` inside useEffect while the hook is active/mounted.

## Why

If the component where the hook is present gets unmounted, even if `unobserve` was called, setState will generate the following warning:

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```

## How

By simply guarding with a flag that changes on the effect's cleanup.

## Checklist

Have you done all of these things?

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added "N/A"
- [ ] Tests "N/A"
- [ ] TypeScript definitions updated "N/A"
- [x] Ready to be merged
