### PR TITLE
chore: downgrade to node 16 to fix the build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 17.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!--
  Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

  Before submitting a pull request, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

  Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

  If you're new to contributing to open source projects, you might find this free video course helpful: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github

  Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## What

Downgrading Node to version 16 in order to fix a build error.

## Why

With Node 17 we are having the following message: `Error: error:0308010C:digital envelope routines::unsupported`. Downgrading to Node 16 seems better than forcing `export NODE_OPTIONS=--openssl-legacy-provider` and
possibly running with [known insecure SSL](https://www.openssl.org/docs/manmaster/man7/OSSL_PROVIDER-legacy.html).

Reference:
https://github.com/webpack/webpack/issues/14532#issuecomment-947807590

## How

By simply downgrading the Node version in workflow/ci.yml

## Checklist

Have you done all of these things?

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added "N/A"
- [ ] Tests "N/A"
- [ ] TypeScript definitions updated "N/A"
- [x] Ready to be merged 
