### PR TITLE
Add shorter syntax option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,25 @@ $ npm install --save react-cool-inview
 
 > ⚠️ [Most modern browsers support Intersection Observer natively](https://caniuse.com/#feat=intersectionobserver). You can also [add polyfill](#intersection-observer-polyfill) for full browser support.
 
-### Basic Use Case
+### Basic usage
+
+Change the `HelloText` depending on whether it is in viewport or not:
+
+```jsx
+import { InView } from "react-cool-inview"
+
+const HelloText = ({ inView, observe }: any) => (
+  <div ref={observe}>{inView ? "Hello, I am 🤗" : "Bye, I am 😴"}</div>
+)
+
+const App = () => (
+  <InView>
+    <HelloText />
+  </InView>
+)
+```
+
+### Using as a React Hook
 
 To monitor an element enters or leaves the viewport by the `inView` state and useful sugar events.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ npm install --save react-cool-inview
 
 ### Basic usage
 
-Change the `HelloText` depending on whether it is in viewport or not:
+Changes `HelloText` when it enters the viewport:
 
 ```jsx
 import { InView } from "react-cool-inview"
@@ -61,11 +61,13 @@ const HelloText = ({ inView, observe }: any) => (
 )
 
 const App = () => (
-  <InView>
+  <InView unobserveOnEnter>
     <HelloText />
   </InView>
 )
 ```
+
+> 💡 `InView` passes `observe` and other props (listed below) to the `HelloText`.
 
 ### Using as a React Hook
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,7 @@ const useInView = <T extends HTMLElement | null>({
   return { ...state, observe, unobserve, updatePosition };
 };
 
-type InViewProps = {
+export interface InViewProps extends Options<HTMLElement | null> {
   children: React.ReactElement
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 
 import useLatest from "./useLatest";
 
@@ -192,5 +192,15 @@ const useInView = <T extends HTMLElement | null>({
 
   return { ...state, observe, unobserve, updatePosition };
 };
+
+type InViewProps = {
+  children: React.ReactElement
+  options?: Options<any>
+}
+
+export const InView = ({ children, options }: InViewProps) => {
+  const { observe, ...rest } = useInView(options)
+  return React.cloneElement(children, { observe, ...rest })
+}
 
 export default useInView;

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,11 +195,10 @@ const useInView = <T extends HTMLElement | null>({
 
 type InViewProps = {
   children: React.ReactElement
-  options?: Options<any>
 }
 
-export const InView = ({ children, options }: InViewProps) => {
-  const { observe, ...rest } = useInView(options)
+export const InView = ({ children, ...props }: InViewProps) => {
+  const { observe, ...rest } = useInView(props)
   return React.cloneElement(children, { observe, ...rest })
 }
 


### PR DESCRIPTION
This makes the following usage possible:

```jsx
// This is an example of showing (animating) a React component when it appears in viewport:
import React from "react"
import { InView } from "react-cool-inview"

const FancyComponent = ({ inView, observe }: any) => (
  <div ref={observe} className={inView ? "opacity-1" : "opacity-0"}>
    {"Hello"}
  </div>
)

const App = () => (
  <InView unobserveOnEnter>
    <FancyComponent />
  </InView>
)
```

### Why?
It's much shorter than using hooks in this case which allows to style components faster. It's also more readable as it separates the logic from JSX.