### PR TITLE
Fix demo: slides not synchronized with intersection root

### DIFF
--- a/app/src/App/index.tsx
+++ b/app/src/App/index.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { useState } from "react";
+import { useState, useRef } from "react";
 
 import GitHubCorner from "../GitHubCorner";
 import Slider from "../Slider";
@@ -28,6 +28,7 @@ const emojis = [
 
 const App: FC = () => {
   const [state, setState] = useState<State>({ str: emojis[0], dir: "" });
+  const sliderRef = useRef<HTMLDivElement>(null);
 
   const renderCards = (): JSX.Element[] =>
     emojis.map((emoji) => (
@@ -37,6 +38,7 @@ const App: FC = () => {
         onEnter={(str: string, dir: string) => {
           setState({ str, dir });
         }}
+        root={sliderRef.current}
       />
     ));
 
@@ -53,7 +55,7 @@ const App: FC = () => {
       <div className={styles.log}>
         Hello! <Slider string={str} direction={dir} /> comes in.
       </div>
-      <div className={styles.frame}>{renderCards()}</div>
+      <div ref={sliderRef} className={styles.frame}>{renderCards()}</div>
     </div>
   );
 };

--- a/app/src/App/index.tsx
+++ b/app/src/App/index.tsx
@@ -55,7 +55,9 @@ const App: FC = () => {
       <div className={styles.log}>
         Hello! <Slider string={str} direction={dir} /> comes in.
       </div>
-      <div ref={sliderRef} className={styles.frame}>{renderCards()}</div>
+      <div ref={sliderRef} className={styles.frame}>
+        {renderCards()}
+      </div>
     </div>
   );
 };

--- a/app/src/Card/index.tsx
+++ b/app/src/Card/index.tsx
@@ -5,7 +5,7 @@ import styles from "./styles.module.scss";
 interface Props {
   string: string;
   onEnter: (str: string, dir: string) => void;
-  root: HTMLDivElement|null;
+  root: HTMLDivElement | null;
 }
 
 export default ({ string, onEnter, root }: Props): JSX.Element => {

--- a/app/src/Card/index.tsx
+++ b/app/src/Card/index.tsx
@@ -5,10 +5,13 @@ import styles from "./styles.module.scss";
 interface Props {
   string: string;
   onEnter: (str: string, dir: string) => void;
+  root: HTMLDivElement|null;
 }
 
-export default ({ string, onEnter }: Props): JSX.Element => {
+export default ({ string, onEnter, root }: Props): JSX.Element => {
   const { observe } = useInView<HTMLDivElement>({
+    root,
+    rootMargin: "-20px", // update if you change card margin
     threshold: 0.5,
     onEnter: ({ scrollDirection }) => {
       onEnter(string, scrollDirection.vertical || "");


### PR DESCRIPTION
This fixes #720 , by setting the root and card margin to make the two slides synchronized and tigger the events at the same time (enter/leave)



## Checklist

- [ ] Documentation added
- [ ] Tests
- [ ] TypeScript definitions updated
- [ ] Ready to be merged
- [x] Demo
